### PR TITLE
42 implement card overlay design

### DIFF
--- a/extension/contentScripts/commentContainer/commentContainer.css
+++ b/extension/contentScripts/commentContainer/commentContainer.css
@@ -5,9 +5,9 @@ commentsContainer {
     margin: auto;
     min-height: 100vh;
     position: absolute;
-    right: -320 px;
+    right: -370px;
     top: 0px;
-    width: 350px;
+    width: 400px;
     z-index: 9001;
 }
 
@@ -15,9 +15,8 @@ commentsContainer {
     background-color: rgb(53, 53, 53);
     display: flex;
     margin-bottom: 5px;
-    width: 100%;
-    padding: 5px;
-    padding-left: 30px;
+    max-width: 100%;
+    padding: 5px 25px 5px 30px;
     transition: all 0.25s ease-in-out;
         -webkit-transition: all 0.25s ease-in-out; /** Chrome & Safari **/
         -moz-transition: all 0.25s ease-in-out; /** Firefox **/
@@ -25,10 +24,10 @@ commentsContainer {
 }
 
 .commentBox.slideOut, .commentBox:hover {
-    transform: translate(-365px,0);
-    -webkit-transform: translate(-365px,0); /** Chrome & Safari **/
-    -o-transform: translate(-365px,0); /** Opera **/
-    -moz-transform: translate(-365px,0); /** Firefox **/
+    transform: translate(-360px,0);
+    -webkit-transform: translate(-360px,0); /** Chrome & Safari **/
+    -o-transform: translate(-360px,0); /** Opera **/
+    -moz-transform: translate(-360px,0); /** Firefox **/
 }
 
 .commentBox.default, .annotatedElem {

--- a/extension/contentScripts/commentContainer/commentContainer.css
+++ b/extension/contentScripts/commentContainer/commentContainer.css
@@ -3,12 +3,11 @@ commentsContainer {
     font-family: 'roboto', arial;
     height: 100%;
     margin: auto;
-    max-width: 500px;
     min-height: 100vh;
-    min-width: 300px;
     position: absolute;
-    right: -350px;
-    width: 33vw;
+    right: -335px;
+    top: 0px;
+    width: 350px;
     z-index: 9001;
 
 }
@@ -17,12 +16,35 @@ commentsContainer {
     background-color: rgb(53, 53, 53);
     display: flex;
     margin-bottom: 5px;
+    /* margin-left: -10px; */
     max-width: 100%;
-    padding: 3px;
+    padding: 5px;
+    padding-left: 20px;
+
+    transition: all 0.25s ease-in-out;
+    -webkit-transition: all 0.25s ease-in-out; /** Chrome & Safari **/
+    -moz-transition: all 0.25s ease-in-out; /** Firefox **/
+    -o-transition: all 0.25s ease-in-out; /** Opera **/
+}
+
+.commentBox.slideOut {
+    /* margin-left: -385px; */
+    transform: translate(-335px,0);
+    -webkit-transform: translate(-335px,0); /** Chrome & Safari **/
+    -o-transform: translate(-335px,0); /** Opera **/
+    -moz-transform: translate(-335px,0); /** Firefox **/
 }
 
 .commentBox:hover {
-    margin-left: -350px;
+    /* margin-left: -385px; */
+    transform: translate(-335px,0);
+    -webkit-transform: translate(-335px,0); /** Chrome & Safari **/
+    -o-transform: translate(-335px,0); /** Opera **/
+    -moz-transform: translate(-335px,0); /** Firefox **/
+}
+
+.commentBox.default {
+    background-color: #f3936ecf;
 }
 
 .commentBox.pink {

--- a/extension/contentScripts/commentContainer/commentContainer.css
+++ b/extension/contentScripts/commentContainer/commentContainer.css
@@ -1,46 +1,28 @@
 commentsContainer {
-    background-color: white;
-    box-shadow: rgba(0, 0, 0, 0.2) -20px 0px 10px 0px;
-    -webkit-box-shadow: rgba(0, 0, 0, 0.2) -20px 0px 10px 0px;
-    -moz-box-shadow: rgba(0, 0, 0, 0.2) -20px 0px 10px 0px;
+    background-color: none;
     font-family: 'roboto', arial;
     height: 100%;
-    margin: -8px 0em 0em;
+    margin: auto;
     max-width: 500px;
     min-height: 100vh;
     min-width: 300px;
+    position: absolute;
+    right: -350px;
     width: 33vw;
-}
+    z-index: 9001;
 
-.dark {
-    background-color: #353535;
-}
-
-#containerHeader {
-    background-color: none;
-    color: blueviolet;
-    margin: 5px 0 0 0;
-    text-align: center;
-}
-
-.dark#containerHeader {
-    color: rgb(215, 82, 255);
-}
-
-#comments {
-    display: flex;
-    flex-direction: column;
-    /*Shouldn't need to be done with the proper 2X shadow dom implementation*/
-    overflow-x: hidden;
-    overflow-y: auto;
-    padding: 0 5px;
 }
 
 .commentBox {
+    background-color: rgb(53, 53, 53);
     display: flex;
     margin-bottom: 5px;
+    max-width: 100%;
     padding: 3px;
-    background-color: rgb(53, 53, 53);
+}
+
+.commentBox:hover {
+    margin-left: -350px;
 }
 
 .commentBox.pink {
@@ -65,11 +47,11 @@ commentsContainer {
     resize: none;
 }
 
-.dark.commentTextArea {
-    background-color: #353535;;
+/* Revisit dark mode at a later date*/
+/* .dark.commentTextArea {
+    background-color: #353535;
     color: white;
-
-}
+} */
 
 .controls {
     flex: 1;

--- a/extension/contentScripts/commentContainer/commentContainer.css
+++ b/extension/contentScripts/commentContainer/commentContainer.css
@@ -5,62 +5,34 @@ commentsContainer {
     margin: auto;
     min-height: 100vh;
     position: absolute;
-    right: -335px;
+    right: -320 px;
     top: 0px;
     width: 350px;
     z-index: 9001;
-
 }
 
 .commentBox {
     background-color: rgb(53, 53, 53);
     display: flex;
     margin-bottom: 5px;
-    /* margin-left: -10px; */
-    max-width: 100%;
+    width: 100%;
     padding: 5px;
-    padding-left: 20px;
-
+    padding-left: 30px;
     transition: all 0.25s ease-in-out;
-    -webkit-transition: all 0.25s ease-in-out; /** Chrome & Safari **/
-    -moz-transition: all 0.25s ease-in-out; /** Firefox **/
-    -o-transition: all 0.25s ease-in-out; /** Opera **/
+        -webkit-transition: all 0.25s ease-in-out; /** Chrome & Safari **/
+        -moz-transition: all 0.25s ease-in-out; /** Firefox **/
+        -o-transition: all 0.25s ease-in-out; /** Opera **/
 }
 
-.commentBox.slideOut {
-    /* margin-left: -385px; */
-    transform: translate(-335px,0);
-    -webkit-transform: translate(-335px,0); /** Chrome & Safari **/
-    -o-transform: translate(-335px,0); /** Opera **/
-    -moz-transform: translate(-335px,0); /** Firefox **/
+.commentBox.slideOut, .commentBox:hover {
+    transform: translate(-365px,0);
+    -webkit-transform: translate(-365px,0); /** Chrome & Safari **/
+    -o-transform: translate(-365px,0); /** Opera **/
+    -moz-transform: translate(-365px,0); /** Firefox **/
 }
 
-.commentBox:hover {
-    /* margin-left: -385px; */
-    transform: translate(-335px,0);
-    -webkit-transform: translate(-335px,0); /** Chrome & Safari **/
-    -o-transform: translate(-335px,0); /** Opera **/
-    -moz-transform: translate(-335px,0); /** Firefox **/
-}
-
-.commentBox.default {
+.commentBox.default, .annotatedElem {
     background-color: #f3936ecf;
-}
-
-.commentBox.pink {
-    background-color: fuchsia;
-}
-
-.commentBox.yellow {
-    background-color: yellow;
-}
-
-.commentBox.cyan {
-    background-color: cyan;
-}
-
-.commentBox.green {
-    background-color: greenyellow;
 }
 
 .commentTextArea {

--- a/extension/contentScripts/commentContainer/commentContainer.js
+++ b/extension/contentScripts/commentContainer/commentContainer.js
@@ -349,7 +349,8 @@ function randomColour() {
     max = colors.length;
     let randomIndex = Math.floor(Math.random() * (max - min)) + min;
 
-    return colors[randomIndex];
+    //Making default permanent for now, will remove randomisation and make colours indicative of urgency/purpose/user set in another issue
+    return 'default';
 }
 
 function checkTheme() {

--- a/extension/contentScripts/commentContainer/commentContainer.js
+++ b/extension/contentScripts/commentContainer/commentContainer.js
@@ -16,60 +16,61 @@ currentAnnotationInstance = {
 // TODO if the user leaves the page when this array is populated, alert are they sure they want to leave-
 draftAnnotations = [];
 
-let annotationSort = 'Element';
+// let annotationSort = 'Element';
 
-function changeSort() {
-    let sortOrder = document.querySelector('select#annotationSort').value;
+// function changeSort() {
+//     let sortOrder = document.querySelector('select#annotationSort').value;
 
-    if (draftAnnotations.length > 0) {
-        alert('Please delete or save current draft');
-        document.querySelector('select#annotationSort').value = annotationSort;
-    } else if (currentAnnotationInstance.annotations.length < 1) {
-        alert('Nothing to sort... Annotate some things first!');
-        document.querySelector('select#annotationSort').value = annotationSort;
-    } else {
-        annotationSort = sortOrder;
-        SortAnnotations();
-    }
-}
-function SortAnnotations(redrawAnnotations = true) {
-    if (annotationSort === 'Element') {
-        currentAnnotationInstance.annotations.sort(function (annotation1, annotation2) {
-            if (annotation1.elementAuditID > annotation2.elementAuditID)
-            {
-                return 1;
-            }
-            if (annotation1.elementAuditID < annotation2.elementAuditID)
-            {
-                return -1;
-            }
-            if (annotation1.elementAuditID === annotation2.elementAuditID)
-            {
-                return annotation1.created - annotation2.created;
-            }
-        });
-    } else if (annotationSort === 'Created') {
-        currentAnnotationInstance.annotations.sort(function (annotation1, annotation2) {
-            return annotation1.created - annotation2.created;
-        });
-    }
+//     if (draftAnnotations.length > 0) {
+//         alert('Please delete or save current draft');
+//         document.querySelector('select#annotationSort').value = annotationSort;
+//     } else if (currentAnnotationInstance.annotations.length < 1) {
+//         alert('Nothing to sort... Annotate some things first!');
+//         document.querySelector('select#annotationSort').value = annotationSort;
+//     } else {
+//         annotationSort = sortOrder;
+//         SortAnnotations();
+//     }
+// }
 
-    if (redrawAnnotations) {
-        //Remove all annotation template elements
-        let commentsElem = document.querySelector('div#comments');
-        while (commentsElem.firstChild) {
-            commentsElem.removeChild(commentsElem.firstChild);
-        }
+// function SortAnnotations(redrawAnnotations = true) {
+//     if (annotationSort === 'Element') {
+//         currentAnnotationInstance.annotations.sort(function (annotation1, annotation2) {
+//             if (annotation1.elementAuditID > annotation2.elementAuditID)
+//             {
+//                 return 1;
+//             }
+//             if (annotation1.elementAuditID < annotation2.elementAuditID)
+//             {
+//                 return -1;
+//             }
+//             if (annotation1.elementAuditID === annotation2.elementAuditID)
+//             {
+//                 return annotation1.created - annotation2.created;
+//             }
+//         });
+//     } else if (annotationSort === 'Created') {
+//         currentAnnotationInstance.annotations.sort(function (annotation1, annotation2) {
+//             return annotation1.created - annotation2.created;
+//         });
+//     }
 
-        // redraw annotations
-        // for all annotations, load
-        currentAnnotationInstance.annotations.forEach(annotation => {
-            displayAnnotation(annotation);
-            setEditMode(annotation.ID, false);
-        });
-    }
+//     if (redrawAnnotations) {
+//         //Remove all annotation template elements
+//         let commentsElem = document.querySelector('commentscontainer');
+//         while (commentsElem.firstChild) {
+//             commentsElem.removeChild(commentsElem.firstChild);
+//         }
 
-}
+//         // redraw annotations
+//         // for all annotations, load
+//         currentAnnotationInstance.annotations.forEach(annotation => {
+//             displayAnnotation(annotation);
+//             setEditMode(annotation.ID, false);
+//         });
+//     }
+
+// }
 
 // Create annotation object
 function CreateDraftAnnotation(annotationData) {
@@ -285,7 +286,7 @@ function CancelAnnotation(buttonClick) {
 
 // show annotation 
 function displayAnnotation(annotation) {
-    let commentsDiv = document.querySelector('div#comments');
+    let commentsDiv = document.querySelector('commentscontainer');
     let commentBoxTemplate = document.querySelector('template');
 
     //Create new comment instance
@@ -358,7 +359,6 @@ function checkTheme() {
 
 function changeTheme() {
     let commentsContainer = document.querySelector('commentscontainer');
-    let containerHeader = document.querySelector('#containerHeader');
     let commentTextAreas = [...document.getElementsByClassName('commentTextArea')];
 
     let isInDarkMode = checkTheme();
@@ -366,7 +366,6 @@ function changeTheme() {
     if (isInDarkMode) {
         // remove dark mode classes
         commentsContainer.classList.remove('dark');
-        containerHeader.classList.remove('dark');
         commentTextAreas.forEach(cta => {
             cta.classList.remove('dark');
         });
@@ -374,7 +373,6 @@ function changeTheme() {
     } else {
         // add dark mode classes
         commentsContainer.classList.add('dark');
-        containerHeader.classList.add('dark');
         commentTextAreas.forEach(cta => cta.classList.add('dark'));
     }
 }

--- a/extension/contentScripts/commentContainer/commentContainer.js
+++ b/extension/contentScripts/commentContainer/commentContainer.js
@@ -210,9 +210,26 @@ function SaveAnnotation(buttonClick) {
 
         setEditMode(annotationId, false);
 
+        //Add hover event trigger to annotated elem
+        attachAnnotatedElementTrigger(annotationId, annotationToSave.elementAuditID, annotationToSave.selectionText);
+
         SortAnnotations();
     }
 }
+
+//selectionText is unused for now
+//Style and attach a hover event
+function attachAnnotatedElementTrigger(annotationId, elementAuditID, selectionText) {
+    let annotatedElem = document.querySelector('[element_audit_id="' + annotationId + '"]');
+    let annotationBox = document.querySelector('[annotationid="' + annotationId + '"]');
+
+    //Style
+
+
+    //Attach trigger
+
+}
+
 
 function DeleteAnnotation(buttonClick) {
     let annotationId =  getIDFromButtonClick(buttonClick);

--- a/extension/contentScripts/commentContainer/commentContainer.js
+++ b/extension/contentScripts/commentContainer/commentContainer.js
@@ -340,7 +340,7 @@ function displayAnnotation(annotation) {
     });
 
     let annotationBox = clone.querySelector('.commentBox');
-    annotationBox.classList.add(randomColour());
+    annotationBox.classList.add('default');
     annotationBox.setAttribute('annotationId', annotation.ID);
 
     // For demo populate annotation with selected text
@@ -356,16 +356,6 @@ function displayAnnotation(annotation) {
     }
 
     commentsDiv.appendChild(clone);
-}
-
-function randomColour() {
-    let colors = ['pink', 'yellow', 'cyan', 'green'];
-    min = 0;
-    max = colors.length;
-    let randomIndex = Math.floor(Math.random() * (max - min)) + min;
-
-    //Making default permanent for now, will remove randomisation and make colours indicative of urgency/purpose/user set in another issue
-    return 'default';
 }
 
 function checkTheme() {

--- a/extension/contentScripts/commentContainer/commentContainer.js
+++ b/extension/contentScripts/commentContainer/commentContainer.js
@@ -16,61 +16,60 @@ currentAnnotationInstance = {
 // TODO if the user leaves the page when this array is populated, alert are they sure they want to leave-
 draftAnnotations = [];
 
-// let annotationSort = 'Element';
+let annotationSort = 'Element';
 
-// function changeSort() {
-//     let sortOrder = document.querySelector('select#annotationSort').value;
+function changeSort() {
+    let sortOrder = document.querySelector('select#annotationSort').value;
 
-//     if (draftAnnotations.length > 0) {
-//         alert('Please delete or save current draft');
-//         document.querySelector('select#annotationSort').value = annotationSort;
-//     } else if (currentAnnotationInstance.annotations.length < 1) {
-//         alert('Nothing to sort... Annotate some things first!');
-//         document.querySelector('select#annotationSort').value = annotationSort;
-//     } else {
-//         annotationSort = sortOrder;
-//         SortAnnotations();
-//     }
-// }
+    if (draftAnnotations.length > 0) {
+        alert('Please delete or save current draft');
+        document.querySelector('select#annotationSort').value = annotationSort;
+    } else if (currentAnnotationInstance.annotations.length < 1) {
+        alert('Nothing to sort... Annotate some things first!');
+        document.querySelector('select#annotationSort').value = annotationSort;
+    } else {
+        annotationSort = sortOrder;
+        SortAnnotations();
+    }
+}
 
-// function SortAnnotations(redrawAnnotations = true) {
-//     if (annotationSort === 'Element') {
-//         currentAnnotationInstance.annotations.sort(function (annotation1, annotation2) {
-//             if (annotation1.elementAuditID > annotation2.elementAuditID)
-//             {
-//                 return 1;
-//             }
-//             if (annotation1.elementAuditID < annotation2.elementAuditID)
-//             {
-//                 return -1;
-//             }
-//             if (annotation1.elementAuditID === annotation2.elementAuditID)
-//             {
-//                 return annotation1.created - annotation2.created;
-//             }
-//         });
-//     } else if (annotationSort === 'Created') {
-//         currentAnnotationInstance.annotations.sort(function (annotation1, annotation2) {
-//             return annotation1.created - annotation2.created;
-//         });
-//     }
+function SortAnnotations(redrawAnnotations = true) {
+    if (annotationSort === 'Element') {
+        currentAnnotationInstance.annotations.sort(function (annotation1, annotation2) {
+            if (annotation1.elementAuditID > annotation2.elementAuditID)
+            {
+                return 1;
+            }
+            if (annotation1.elementAuditID < annotation2.elementAuditID)
+            {
+                return -1;
+            }
+            if (annotation1.elementAuditID === annotation2.elementAuditID)
+            {
+                return annotation1.created - annotation2.created;
+            }
+        });
+    } else if (annotationSort === 'Created') {
+        currentAnnotationInstance.annotations.sort(function (annotation1, annotation2) {
+            return annotation1.created - annotation2.created;
+        });
+    }
 
-//     if (redrawAnnotations) {
-//         //Remove all annotation template elements
-//         let commentsElem = document.querySelector('commentscontainer');
-//         while (commentsElem.firstChild) {
-//             commentsElem.removeChild(commentsElem.firstChild);
-//         }
+    if (redrawAnnotations) {
+        //Remove all annotation template elements
+        let commentsElem = document.querySelector('commentscontainer');
+        while (commentsElem.firstChild) {
+            commentsElem.removeChild(commentsElem.firstChild);
+        }
 
-//         // redraw annotations
-//         // for all annotations, load
-//         currentAnnotationInstance.annotations.forEach(annotation => {
-//             displayAnnotation(annotation);
-//             setEditMode(annotation.ID, false);
-//         });
-//     }
-
-// }
+        // redraw annotations
+        // for all annotations, load
+        currentAnnotationInstance.annotations.forEach(annotation => {
+            displayAnnotation(annotation);
+            setEditMode(annotation.ID, false);
+        });
+    }
+}
 
 // Create annotation object
 function CreateDraftAnnotation(annotationData) {
@@ -318,7 +317,6 @@ function displayAnnotation(annotation) {
         CancelAnnotation(annotation);
     });
 
-    
     let updateButton = clone.querySelector('button#update');
     updateButton.addEventListener('click', function (annotation) {
         UpdateAnnotation(annotation);

--- a/extension/contentScripts/content.css
+++ b/extension/contentScripts/content.css
@@ -1,3 +1,0 @@
-#alteredBody {
-    display: flex;
-}

--- a/extension/contentScripts/content.js
+++ b/extension/contentScripts/content.js
@@ -141,38 +141,4 @@ document.addEventListener("mousedown", function(event){
     }
 }, true);
 
-document.addEventListener('keydown', HandleKeyDown);
-document.addEventListener('keyup', HandleKeyUp);
-let pressedKeys = [];
-
-function HandleKeyDown(keyPress) {
-    pressedKeys[keyPress.key] = true;
-    keyChange();
-}
-
-function HandleKeyUp(keyPress) {
-    pressedKeys[keyPress.key] = false;
-    keyChange();
-}
-
-function keyChange() {
-    if (pressedKeys.altKey && pressedKeys.o) {
-        SlideOutCards();
-    } else {
-        SlideBackCards();
-    }
-}
-
-function SlideOutCards() {
-    let commentsContainerElem = document.querySelector('commentscontainer');
-
-    commentsContainerElem.children.forEach(annotation => annotation.classlist.add('slideOut'));
-}
-
-function SlideBackCards() {
-    let commentsContainerElem = document.querySelector('commentscontainer');
-
-    commentsContainerElem.children.forEach(annotation => annotation.classlist.remove('slideOut'));
-}
-
 console.log('ready for lift off');

--- a/extension/contentScripts/content.js
+++ b/extension/contentScripts/content.js
@@ -116,8 +116,6 @@ function createCommentContainer() {
         '</div>' +
     '</template>';
 
-    document.body.id = 'alteredBody';
-
     // if the user has set the theme to be dark mode by default, change to dark mode
     if (darkModeByDefault) 
     {
@@ -146,5 +144,39 @@ document.addEventListener("mousedown", function(event){
         chrome.runtime.sendMessage(message);
     }
 }, true);
+
+document.addEventListener('keydown', HandleKeyDown);
+document.addEventListener('keyup', HandleKeyUp);
+let pressedKeys = [];
+
+function HandleKeyDown(keyPress) {
+    pressedKeys[keyPress.key] = true;
+    keyChange();
+}
+
+function HandleKeyUp(keyPress) {
+    pressedKeys[keyPress.key] = false;
+    keyChange();
+}
+
+function keyChange() {
+    if (pressedKeys.altKey && pressedKeys.o) {
+        SlideOutCards();
+    } else {
+        SlideBackCards();
+    }
+}
+
+function SlideOutCards() {
+    let commentsContainerElem = document.querySelector('commentscontainer');
+
+    commentsContainerElem.children.forEach(annotation => annotation.classlist.add('slideOut'));
+}
+
+function SlideBackCards() {
+    let commentsContainerElem = document.querySelector('commentscontainer');
+
+    commentsContainerElem.children.forEach(annotation => annotation.classlist.remove('slideOut'));
+}
 
 console.log('ready for lift off');

--- a/extension/contentScripts/content.js
+++ b/extension/contentScripts/content.js
@@ -51,7 +51,7 @@ function ChangeContainerState() {
 
 function LoadExtension() {
     addScriptsToPage();
-    containPageContent();
+    //containPageContent();
     AuditElements();
     createCommentContainer();
     loadAnnotationsFromCache();
@@ -68,7 +68,7 @@ function UnloadExtension() {
 // Label all elements on the page we can authenticate an element is the same as it was when created by comparing auditID and element type
 function AuditElements() {
     elementCounter = 1;
-    elementsToAudit = document.getElementById('containedBody');
+    elementsToAudit = document.querySelector('body');
     elementsToAudit.querySelectorAll('*').forEach(function(element) {
         element.setAttribute('element_audit_id', elementCounter);
         elementCounter++;
@@ -90,17 +90,14 @@ function containPageContent() {
 function createCommentContainer() {
     document.body.innerHTML = document.body.innerHTML +
     '<commentsContainer>' +
-        '<h1 id=containerHeader >' +
-            'Annotations' +
-        '</h1>' +
-        '<div id="containerOptions">' +
-            '<button id="share">Share</button>' +
-            '<select id="annotationSort">' +
-                '<option value="Element">Sort by Element</option>' +
-                '<option value="Created">Sort by Created</option>' +
-            '</select>' +
-        '</div>' +
-        '<div id="comments" ></div>' +
+    //Hidden controls for now, will in the future move to popup js
+        // '<div id="containerOptions">' +
+        //     '<button id="share">Share</button>' +
+        //     '<select id="annotationSort">' +
+        //         '<option value="Element">Sort by Element</option>' +
+        //         '<option value="Created">Sort by Created</option>' +
+        //     '</select>' +
+        // '</div>' +
     '</commentsContainer>' +
 
     '<template>' +
@@ -127,10 +124,10 @@ function createCommentContainer() {
         changeTheme();
     }
 
-    let sortDropdown = document.querySelector('select#annotationSort');
-    sortDropdown.addEventListener('change', function () {
-        changeSort();
-    });
+    // let sortDropdown = document.querySelector('select#annotationSort');
+    // sortDropdown.addEventListener('change', function () {
+    //     changeSort();
+    // });
 }
 
 // Work out what element was right clicked

--- a/extension/contentScripts/content.js
+++ b/extension/contentScripts/content.js
@@ -40,9 +40,7 @@ chrome.storage.sync.get('activeOnPageLoad', function (data) {
 });
 
 function ChangeContainerState() {
-    if (containerStateActive) {
-        UnloadExtension();
-    } else {
+    if (!containerStateActive) {
         LoadExtension();
     }
 
@@ -55,14 +53,6 @@ function LoadExtension() {
     AuditElements();
     createCommentContainer();
     loadAnnotationsFromCache();
-}
-
-function UnloadExtension() {
-    // container is active so release the content
-    let originalPageContentsElem = document.getElementById('containedBody');
-    let originalPageContents = originalPageContentsElem.innerHTML;
-    document.body.innerHTML = originalPageContents;
-    document.body.removeAttribute("id");
 }
 
 // Label all elements on the page we can authenticate an element is the same as it was when created by comparing auditID and element type
@@ -90,6 +80,9 @@ function containPageContent() {
 function createCommentContainer() {
     document.body.innerHTML = document.body.innerHTML +
     '<commentsContainer>' +
+
+
+
     //Hidden controls for now, will in the future move to popup js
         // '<div id="containerOptions">' +
         //     '<button id="share">Share</button>' +
@@ -98,6 +91,9 @@ function createCommentContainer() {
         //         '<option value="Created">Sort by Created</option>' +
         //     '</select>' +
         // '</div>' +
+
+
+        
     '</commentsContainer>' +
 
     '<template>' +


### PR DESCRIPTION
Removes most of the prototype styling and implements a new UI I've ended up calling cards.

Resolving: #1 (Should have been closed once it was broken down, to be honest), #32, #42 
This is the beginning of the redesign however this has been done so far:

- Cards contain user annotations
- Cards pop out on top of the page
- Content no longer has to be contained!

But, there are still some issues to resolve:

- Highlight annotated elements and add hover triggers for the corresponding annotation #22
- Wrap the cards in a shadow dom to encapsulate JS and CSS #44
- toggle a slide out of all cards based on a key shortcut #21
- migrate controls like the sort dropdown to the popup #45
- migrate draft annotation to popup #39

However, I'm taking a small break to address the growing housekeeping issues:
- Setting up a linter to find any small issues with my code #47
- Before the card UI is finished and merged, perform a review of the code quality